### PR TITLE
Add BASH/ZSH/FISH shell completions [require manual install]

### DIFF
--- a/shellCompletions/_turbocrypt
+++ b/shellCompletions/_turbocrypt
@@ -1,0 +1,103 @@
+#compdef turbocrypt
+
+# turbocrypt zsh completion — shows files for encrypt/decrypt/verify when current token is NOT an option
+
+local -a subs
+subs=( keygen change-password encrypt decrypt verify config bench )
+
+# If completing the subcommand itself (pos 2), show subcommands + top-level help
+if (( CURRENT == 2 )); then
+  compadd -a subs
+  compadd -- -h --help
+  return 0
+fi
+
+# Determine the chosen subcommand (first non-option arg)
+local subcmd
+for (( i = 2; i <= $#words; i++ )); do
+  if [[ ${words[i]} != -* ]]; then
+    subcmd=${words[i]}; break
+  fi
+done
+
+# fallback: show top-level if none found
+if [[ -z $subcmd ]]; then
+  compadd -a subs
+  compadd -- -h --help
+  return 0
+fi
+
+case $subcmd in
+  keygen)
+    if [[ ${words[CURRENT]} == --* || ${words[CURRENT]} == -* ]]; then
+      compadd -- --password
+      return 0
+    fi
+    _files && return 0
+    ;;
+  change-password)
+    if [[ ${words[CURRENT]} == --* || ${words[CURRENT]} == -* ]]; then
+      compadd -- --remove-password
+      return 0
+    fi
+    _files && return 0
+    ;;
+  encrypt|decrypt)
+    # If token starts with '-' => show options. Otherwise show filenames.
+    if [[ ${words[CURRENT]} == --* || ${words[CURRENT]} == -* ]]; then
+      compadd -- --key --password --in-place --encrypted-filenames --exclude --context --enc-suffix --threads --dry-run
+      return 0
+    fi
+
+    # If previous word is an option that expects a value, complete appropriately
+    case ${words[CURRENT-1]} in
+      --key) _files; return 0 ;;
+      --threads) compadd 1 2 4 8 16 32; return 0 ;;
+      --exclude|--context) return 0 ;; # free string/pattern -> don't list files
+      # flags with no args:
+      --password|--in-place|--encrypted-filenames|--enc-suffix|--dry-run) return 0 ;;
+    esac
+
+    # Otherwise (token doesn't start with '-') provide file/directory completions
+    _files && return 0
+    ;;
+  verify)
+    if [[ ${words[CURRENT]} == --* || ${words[CURRENT]} == -* ]]; then
+      compadd -- --key --quick --context --dry-run
+      return 0
+    fi
+
+    case ${words[CURRENT-1]} in
+      --key) _files; return 0 ;;
+      --context) return 0 ;; # free string
+      --quick|--dry-run) return 0 ;;
+    esac
+
+    _files && return 0
+    ;;
+  config)
+    local -a cfgs
+    cfgs=( show set-key set-threads set-buffer-size add-exclude remove-exclude set-ignore-symlinks set-encrypted-filenames )
+
+    # If completing config-subcommand (pos 3), list them
+    if (( CURRENT == 3 )); then
+      compadd -a cfgs
+      return 0
+    fi
+
+    case ${words[3]} in
+      set-key) _files; return 0 ;;
+      set-threads) compadd 1 2 4 8 16 32; return 0 ;;
+      set-buffer-size) compadd 4096 65536 1048576 8388608; return 0 ;;
+      add-exclude|remove-exclude) _files; return 0 ;;
+      set-ignore-symlinks|set-encrypted-filenames) compadd true false; return 0 ;;
+      *) return 0 ;;
+    esac
+    ;;
+  bench)
+    return 0
+    ;;
+  *)
+    return 0
+    ;;
+esac

--- a/shellCompletions/turbocrypt
+++ b/shellCompletions/turbocrypt
@@ -1,0 +1,117 @@
+# turbocrypt bash completion (updated)
+_turbocrypt() {
+    local cur prev words cword
+    if type _get_comp_words_by_ref &>/dev/null; then
+        _get_comp_words_by_ref -n : cur prev words cword
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        prev="${COMP_WORDS[COMP_CWORD-1]}"
+        words=("${COMP_WORDS[@]}")
+        cword=$COMP_CWORD
+    fi
+
+    local subcommands=(keygen change-password encrypt decrypt verify config bench)
+    local config_subs=(show set-key set-threads set-buffer-size add-exclude remove-exclude set-ignore-symlinks set-encrypted-filenames)
+
+    # find first non-option token (subcommand)
+    local i token subcmd=""
+    for (( i = 1; i < COMP_CWORD; i++ )); do
+        token="${COMP_WORDS[i]}"
+        if [[ "${token}" != -* ]]; then
+            subcmd="${token}"
+            break
+        fi
+    done
+
+    # If no subcommand yet -> list top-level subcommands and top-level help flag
+    if [[ -z "$subcmd" ]]; then
+        # show subcommands; Bash doesn't show descriptions inline, but we list the names.
+        COMPREPLY=( $(compgen -W "${subcommands[*]} -h --help" -- "$cur") )
+        return 0
+    fi
+
+    case "$subcmd" in
+        keygen)
+            if [[ "$cur" == --* || "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "--password -h --help" -- "$cur") )
+                return 0
+            fi
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            return 0
+            ;;
+        change-password)
+            if [[ "$cur" == --* || "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "--remove-password -h --help" -- "$cur") )
+                return 0
+            fi
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            return 0
+            ;;
+        encrypt|decrypt)
+            local opts="--key --password --in-place --encrypted-filenames --exclude --context --enc-suffix --threads --dry-run -h --help"
+            if [[ "$cur" == --* || "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+                return 0
+            fi
+            case "$prev" in
+                --key) COMPREPLY=( $(compgen -f -- "$cur") ); return 0 ;;
+                --password) COMPREPLY=(); return 0 ;;
+                --exclude) COMPREPLY=(); return 0 ;;
+                --context) COMPREPLY=(); return 0 ;;
+                --threads) COMPREPLY=( $(compgen -W "1 2 4 8 16 32" -- "$cur") ); return 0 ;;
+            esac
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            return 0
+            ;;
+        verify)
+            local opts="--key --quick --context --dry-run -h --help"
+            if [[ "$cur" == --* || "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+                return 0
+            fi
+            case "$prev" in
+                --key) COMPREPLY=( $(compgen -f -- "$cur") ); return 0 ;;
+                --context) COMPREPLY=(); return 0 ;;
+            esac
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            return 0
+            ;;
+        config)
+            # If just 'config' so far, show config subcommands and -h/--help
+            if [[ ${COMP_CWORD} -le 2 || "${COMP_WORDS[COMP_CWORD-1]}" == "config" ]]; then
+                COMPREPLY=( $(compgen -W "${config_subs[*]} -h --help" -- "$cur") )
+                return 0
+            fi
+            # determine which config subcommand is present
+            local cfg=""
+            for (( i = 2; i < COMP_CWORD; i++ )); do
+                token="${COMP_WORDS[i]}"
+                if [[ "${token}" != -* ]]; then
+                    cfg="${token}"
+                    break
+                fi
+            done
+            case "$cfg" in
+                show) COMPREPLY=(); return 0 ;;
+                set-key) COMPREPLY=( $(compgen -f -- "$cur") ); return 0 ;;
+                set-threads) COMPREPLY=( $(compgen -W "1 2 4 8 16 32" -- "$cur") ); return 0 ;;
+                set-buffer-size) COMPREPLY=( $(compgen -W "4096 65536 1048576 8388608" -- "$cur") ); return 0 ;;
+                add-exclude|remove-exclude) COMPREPLY=( $(compgen -f -- "$cur") ); return 0 ;;
+                set-ignore-symlinks|set-encrypted-filenames) COMPREPLY=( $(compgen -W "true false" -- "$cur") ); return 0 ;;
+                *) COMPREPLY=(); return 0 ;;
+            esac
+            ;;
+        bench)
+            COMPREPLY=()
+            return 0
+            ;;
+        *)
+            COMPREPLY=()
+            return 0
+            ;;
+    esac
+}
+
+if type complete &>/dev/null; then
+    complete -F _turbocrypt turbocrypt
+fi

--- a/shellCompletions/turbocrypt.fish
+++ b/shellCompletions/turbocrypt.fish
@@ -1,0 +1,77 @@
+# ~/.config/fish/completions/turbocrypt.fish
+# turbocrypt completions (top-level descriptions, --help, allow files for config add/remove-exclude)
+
+set -l cmds 'keygen' 'change-password' 'encrypt' 'decrypt' 'verify' 'config' 'bench'
+
+# Offer top-level commands only when none present; do not show files at this point.
+# Provide per-command descriptions (so the UI shows what each command does).
+complete -c turbocrypt -n 'not __fish_seen_subcommand_from keygen; and not __fish_seen_subcommand_from change-password; and not __fish_seen_subcommand_from encrypt; and not __fish_seen_subcommand_from decrypt; and not __fish_seen_subcommand_from verify; and not __fish_seen_subcommand_from config; and not __fish_seen_subcommand_from bench' --no-files -a keygen -d "Generate a new key"
+complete -c turbocrypt -n 'not __fish_seen_subcommand_from keygen; and not __fish_seen_subcommand_from change-password; and not __fish_seen_subcommand_from encrypt; and not __fish_seen_subcommand_from decrypt; and not __fish_seen_subcommand_from verify; and not __fish_seen_subcommand_from config; and not __fish_seen_subcommand_from bench' --no-files -a change-password -d "Add/change/remove password on a key file"
+complete -c turbocrypt -n 'not __fish_seen_subcommand_from keygen; and not __fish_seen_subcommand_from change-password; and not __fish_seen_subcommand_from encrypt; and not __fish_seen_subcommand_from decrypt; and not __fish_seen_subcommand_from verify; and not __fish_seen_subcommand_from config; and not __fish_seen_subcommand_from bench' --no-files -a encrypt -d "Encrypt files or directories"
+complete -c turbocrypt -n 'not __fish_seen_subcommand_from keygen; and not __fish_seen_subcommand_from change-password; and not __fish_seen_subcommand_from encrypt; and not __fish_seen_subcommand_from decrypt; and not __fish_seen_subcommand_from verify; and not __fish_seen_subcommand_from config; and not __fish_seen_subcommand_from bench' --no-files -a decrypt -d "Decrypt files or directories"
+complete -c turbocrypt -n 'not __fish_seen_subcommand_from keygen; and not __fish_seen_subcommand_from change-password; and not __fish_seen_subcommand_from encrypt; and not __fish_seen_subcommand_from decrypt; and not __fish_seen_subcommand_from verify; and not __fish_seen_subcommand_from config; and not __fish_seen_subcommand_from bench' --no-files -a verify -d "Verify encrypted data integrity"
+complete -c turbocrypt -n 'not __fish_seen_subcommand_from keygen; and not __fish_seen_subcommand_from change-password; and not __fish_seen_subcommand_from encrypt; and not __fish_seen_subcommand_from decrypt; and not __fish_seen_subcommand_from verify; and not __fish_seen_subcommand_from config; and not __fish_seen_subcommand_from bench' --no-files -a config -d "View or change configuration"
+complete -c turbocrypt -n 'not __fish_seen_subcommand_from keygen; and not __fish_seen_subcommand_from change-password; and not __fish_seen_subcommand_from encrypt; and not __fish_seen_subcommand_from decrypt; and not __fish_seen_subcommand_from verify; and not __fish_seen_subcommand_from config; and not __fish_seen_subcommand_from bench' --no-files -a bench -d "Run performance benchmarks"
+
+# Top-level help flags (available before a subcommand)
+complete -c turbocrypt -n 'not __fish_seen_subcommand_from keygen; and not __fish_seen_subcommand_from change-password; and not __fish_seen_subcommand_from encrypt; and not __fish_seen_subcommand_from decrypt; and not __fish_seen_subcommand_from verify; and not __fish_seen_subcommand_from config; and not __fish_seen_subcommand_from bench' -l help -s h -d "Show help"
+
+# ------------------------
+# keygen
+# ------------------------
+complete -c turbocrypt -n '__fish_seen_subcommand_from keygen' -l password -d "Generate a password-protected key"
+complete -c turbocrypt -n '__fish_seen_subcommand_from keygen' -a '(__fish_complete_path)' -d "Output key file"
+
+# ------------------------
+# change-password
+# ------------------------
+complete -c turbocrypt -n '__fish_seen_subcommand_from change-password' -l remove-password -d "Remove password protection from key"
+complete -c turbocrypt -n '__fish_seen_subcommand_from change-password' -a '(__fish_complete_path)' -d "Key file to modify"
+
+# ------------------------
+# encrypt / decrypt / verify common options
+# ------------------------
+for cmd in encrypt decrypt verify
+    complete -c turbocrypt -n "__fish_seen_subcommand_from $cmd" -l key -r -a '(__fish_complete_path)' -d "Path to key file"
+    complete -c turbocrypt -n "__fish_seen_subcommand_from $cmd" -l password -d "Use password-protected key (prompt)"
+    complete -c turbocrypt -n "__fish_seen_subcommand_from $cmd" -l in-place -d "Operate in place (overwrite source)"
+    complete -c turbocrypt -n "__fish_seen_subcommand_from $cmd" -l encrypted-filenames -d "Encrypt/decrypt filenames"
+    complete -c turbocrypt -n "__fish_seen_subcommand_from $cmd" -l enc-suffix -d "Automatically add/remove .enc suffix"
+    # exclude/context are patterns (no file completion)
+    complete -c turbocrypt -n "__fish_seen_subcommand_from $cmd" -l exclude --no-files -r -d "Exclude pattern (glob)"
+    complete -c turbocrypt -n "__fish_seen_subcommand_from $cmd" -l context --no-files -r -d "Context string"
+    complete -c turbocrypt -n "__fish_seen_subcommand_from $cmd" -l threads -r -a "1 2 4 8 16 32" -d "Worker threads"
+    complete -c turbocrypt -n "__fish_seen_subcommand_from $cmd" -l dry-run -d "Preview without performing operation"
+end
+
+# quick verification flag (verify only)
+complete -c turbocrypt -n '__fish_seen_subcommand_from verify' -l quick -d "Quick verification (check only key correctness)"
+
+# ------------------------
+# config subcommands (with helpful descriptions)
+# ------------------------
+complete -c turbocrypt -n '__fish_seen_subcommand_from config' -f -a show -d "Show current configuration"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config' -f -a set-key -d "Set default key path"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config' -f -a set-threads -d "Set default thread count"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config' -f -a set-buffer-size -d "Set IO buffer size (bytes)"
+# add/remove-exclude in config takes file arguments -> allow path completion
+complete -c turbocrypt -n '__fish_seen_subcommand_from config' -f -a add-exclude -d "Add an exclude pattern or file"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config' -f -a remove-exclude -d "Remove an exclude pattern or file"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config' -f -a set-ignore-symlinks -d "Set symlink behavior (true/false)"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config' -f -a set-encrypted-filenames -d "Set default encrypted-filenames behavior (true/false)"
+
+# config args: allow path completion for set-key and add/remove-exclude
+complete -c turbocrypt -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set-key' -a '(__fish_complete_path)' -d "Path to key"
+# add-exclude/remove-exclude in config: allow files or patterns (offer files)
+complete -c turbocrypt -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from add-exclude' -a '(__fish_complete_path)' -d "File or pattern to add to exclude list"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from remove-exclude' -a '(__fish_complete_path)' -d "File or pattern to remove from exclude list"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set-threads' -a "1 2 4 8 16 32" -d "Threads"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set-buffer-size' -a "4096 65536 1048576 8388608" -d "Buffer size (bytes)"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set-ignore-symlinks' -a "true false" -d "Ignore symlinks (true/false)"
+complete -c turbocrypt -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set-encrypted-filenames' -a "true false" -d "Default filename encryption (true/false)"
+
+# ------------------------
+# positional/file completions: only after encrypt/decrypt/verify
+# ------------------------
+complete -c turbocrypt -n '__fish_seen_subcommand_from encrypt; or __fish_seen_subcommand_from decrypt; or __fish_seen_subcommand_from verify' -a '(__fish_complete_path)' -d "File or directory"
+


### PR DESCRIPTION
As the title says, these are partially auto-generated, manually-tweaked shell completions for BASH (turbocrypt), ZSH (_turbocrypt), and FISH for the bash-completions and zsh-completions plugins (no plugin needed for FISH). 

This project is cool, but the command line arguments can be a bit lengthy so I thought to create some completions for them. I may update in the future with more streamlined completions (i.e. from a proper shell agnostic completion generator like crazy-complete or complgen, but I didn't want to learn yet another completion language). 

I have tested these for all the mentioned shells and they work as expected, though FISH behaves a lot better in general with completions, so it is what I recommend.